### PR TITLE
Iconbox can now omit the icon on smartphones.

### DIFF
--- a/src/components/iconbox.js
+++ b/src/components/iconbox.js
@@ -2,16 +2,19 @@ import React from "react";
 import Box from "./box";
 const classNames = require('classnames');
 
-export default ({children, className, icon}) => {
+export default ({children, className, icon, spNoIcon}) => {
   const defaultClasses = [
     'flex',
     'flex-row'
   ];
   const extraClasses = (!className || Array.isArray(className)) ? className : className.split(' ');
 
+  const spNoIconClasses = spNoIcon ? ["hidden", "sm:block"] : null;
+  const iconPartClasses = classNames("mr-4", "flex-shrink-0", spNoIconClasses);
+
   return (
     <Box className={classNames(defaultClasses, extraClasses)}>
-      <div className="mr-4 flex-shrink-0">
+      <div className={iconPartClasses}>
         <span className="text-4xl md:text-5xl">{icon}</span>
       </div>
       <div className="flex-grow break-all sm:break-normal">

--- a/src/pages/social.js
+++ b/src/pages/social.js
@@ -16,7 +16,7 @@ export default ({data}) => {
     const socialAccounts = data.prismic.allSocial_accountss.edges;
     return (
         <Layout pageTitle="Social Network Policy">
-          <IconBox className="border-yellow-600" icon={<FontAwesomeIcon icon={faExclamationCircle} />}>
+          <IconBox className="border-yellow-600" icon={<FontAwesomeIcon icon={faExclamationCircle} />} spNoIcon={true}>
             <div className="divide-y divide-gray-400">
               <div className="pb-2">
                 <h2 className="text-xl font-orbitron">Social Network Policy</h2>


### PR DESCRIPTION
And this new rule is applied to Social Network Policy page.
